### PR TITLE
update logo url

### DIFF
--- a/html/en_index.html
+++ b/html/en_index.html
@@ -15,7 +15,7 @@
         <nav class="navigation">
             <div class="vector-parent">
                 <a href="/en_index.html">
-                    <img class="vector-icon" alt="Logo" src="./public/logo.png">
+                    <img class="vector-icon" alt="Logo" src="https://images.mongulu.cm/logo.jpeg">
                 </a>
                 <div class="currentproject-parent">
                     <a href="/our-projects.html" target="_self">
@@ -42,7 +42,7 @@
                                 <div class="fr">FR</div>
                             </div>
                         </a>
-                        
+
                     </div>
                 </div>
             </div>
@@ -92,7 +92,7 @@
                                     class="blank-line4">&nbsp;</span></span></span><span
                             class="the-collective-takes-its-name"><span>- In "Baka" society, the construction of mongulu huts is done solely by women. This gives them a certain power in social organization, as the construction technique is unique to them; it is not a simple task separation.</span></span></p>
                 </div>
-                
+
             </div>
             <div class="valuescolumn">
                 <div  style="margin: 20px auto; text-align: center;" class="humilitycard"><img style="margin: 20px auto;" class="humility-img-icon" alt="" src="./public/empowermentimg.svg">
@@ -111,14 +111,14 @@
                 <div class="approach">Approach</div>
             </h2>
             <div class="image-and-text"><img class="approach-img-icon" alt="" src="./public/approachimg.svg">
-                <p class="in-order-to">To achieve its vision, the collective relies on co-opted members. 
-                    It welcomes all Cameroonians or affiliates with various digital skills. 
+                <p class="in-order-to">To achieve its vision, the collective relies on co-opted members.
+                    It welcomes all Cameroonians or affiliates with various digital skills.
                     Members are then invited to our 2 monthly events:<br><br>
                         <b>Work & Eat together:</b> Monthly meetings in Paris on the last Friday of the month, allowing us to work in person thanks to teleworking.<br>
                         <b>Débrief:</b> Virtual meetings on the first Thursday of the month (or postponed if the eve of a public holiday) for project reviews and technology watch.<br>
                 </p>
             </div>
-            <p> 
+            <p>
                 It is also during the briefing that they can present new projects that will be integrated if they meet the following criteria:
             </p>
             <div class="frame-parent">

--- a/html/error.html
+++ b/html/error.html
@@ -9,7 +9,7 @@
   }
 
   body {
-    background-image: url("logo.jpeg");
+    background-image: url("https://images.mongulu.cm/logo.jpeg");
   }
 
   h1 {

--- a/html/index.html
+++ b/html/index.html
@@ -14,7 +14,7 @@
         <nav class="navigation">
             <div class="vector-parent">
                 <a href="/">
-                    <img class="vector-icon" alt="Logo" src="./public/logo.png">
+                    <img class="vector-icon" alt="Logo" src="https://images.mongulu.cm/logo.jpeg">
                 </a>
                 <div class="currentproject-parent">
                     <a href="/nos-projets.html" target="_self">
@@ -100,7 +100,7 @@
                                 les femmes. Cela leur donne un certain pouvoir dans l'organisation sociale, en effet la technique
                                 de construction leur est propre, il ne s'agit pas d'une simple séparation des tâches.</span></span></p>
                 </div>
-                
+
             </div>
             <div class="valuescolumn">
                 <div  style="margin: 20px auto; text-align: center;" class="humilitycard"><img style="margin: 20px auto;" class="humility-img-icon" alt="" src="./public/empowermentimg.svg">
@@ -119,14 +119,14 @@
                 <div class="approach">Approche</div>
             </h2>
             <div class="image-and-text"><img class="approach-img-icon" alt="" src="./public/approachimg.svg">
-                <p class="in-order-to">Pour réaliser sa vision, le collectif s'appuie sur des membres cooptés. 
-                    Il accueille tous Camerounais ou affiliés ayant des compétences numériques variées. 
+                <p class="in-order-to">Pour réaliser sa vision, le collectif s'appuie sur des membres cooptés.
+                    Il accueille tous Camerounais ou affiliés ayant des compétences numériques variées.
                     Les membres sont alors invités à nos 2 évennements mensuels:<br><br>
                         <b>Work & Eat together:</b> rencontres mensuelles à Paris le dernier vendredi du mois, permettant de travailler en présentiel grâce au télétravail.<br>
                         <b>Débrief:</b> rendez-vous virtuels le premier jeudi du mois (ou reporté si veille de jour férié) pour bilan des projets et veille technologique.<br>
                 </p>
             </div>
-            <p> 
+            <p>
                 C'est aussi lors du briefing qu'ils peuvent présenter de nouveaux projets qui seront intégrés s'ils satisfont les critères suivants:
             </p>
             <div class="frame-parent">

--- a/html/nos-projets.html
+++ b/html/nos-projets.html
@@ -16,7 +16,7 @@
         <nav class="navigation">
             <div class="vector-parent">
                 <a href="/">
-                    <img class="vector-icon" alt="Logo" src="./public/logo.png">
+                    <img class="vector-icon" alt="Logo" src="https://images.mongulu.cm/logo.jpeg">
                 </a>
                 <div class="currentproject-parent">
                     <a href="/nos-projets.html" target="_self">

--- a/html/our-projects.html
+++ b/html/our-projects.html
@@ -16,7 +16,7 @@
         <nav class="navigation">
             <div class="vector-parent">
                 <a href="/en_index.html">
-                    <img class="vector-icon" alt="Logo" src="./public/logo.png">
+                    <img class="vector-icon" alt="Logo" src="https://images.mongulu.cm/logo.jpeg">
                 </a>
                 <div class="currentproject-parent">
                     <a href="/nos-projets.html" target="_self">


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Switched the site logo to a hosted URL (https://images.mongulu.cm/logo.jpeg) to ensure consistent loading across pages.

- **Bug Fixes**
  - Replaced ./public/logo.png with the hosted logo in the nav of en_index.html, index.html, nos-projets.html, and our-projects.html.
  - Updated error.html background-image to use the hosted logo.

<!-- End of auto-generated description by cubic. -->

